### PR TITLE
Display indices of parameters

### DIFF
--- a/ISF4AE_CommandSelector.cpp
+++ b/ISF4AE_CommandSelector.cpp
@@ -915,8 +915,13 @@ static PF_Err UpdateParamsUI(PF_InData* in_data, PF_OutData* out_data, PF_ParamD
       if (visible) {
         // Set label
         auto label = input->label();
-        if (label.empty())
+        if (label.empty()) {
           label = input->name();
+        }
+
+        if (seqData->showISFOption) {
+          label += " (" + std::to_string(index) + ")";
+        }
 
         ERR(AEUtil::setParamName(globalData->aegpId, in_data, params, index, label));
       }


### PR DESCRIPTION
Because expressions cannot refer to an ISF parameter by name as it changes dynamically,
displaying the ISF parameter's index would be helpful for users to write expressions referring to them consistently.

Also, users can hide the indices by toggling "ISF Option.." to simplify the UI display.

```js
 // This expression will be broken after reloading the project
effect("ISF")("Label of input")
// This way of referring ISF parameter would work unless the order of ISF inputs does not change
effect("ISF")(12) 
```
