### PR TITLE
If long input does not have VALUES array, iterate MIN to MAX

### DIFF
--- a/ISF4AE_CommandSelector.cpp
+++ b/ISF4AE_CommandSelector.cpp
@@ -622,7 +622,7 @@ static PF_Err UpdateParamsUI(PF_InData* in_data, PF_OutData* out_data, PF_ParamD
         // If the input doesn't define values, match ISFEditor's behaviour and list (min,max) range
         // TODO: for large ranges, should possibly switch to a different UI element as ISFEditor does
         if (values.size() == 0) {
-            for (long val = input->minVal().getLongVal(); val <=      input->maxVal().getLongVal(); val++) {
+            for (long val = input->minVal().getLongVal(); val <= input->maxVal().getLongVal(); val++) {
               values.push_back((int)val);
             }
         }

--- a/ISF4AE_CommandSelector.cpp
+++ b/ISF4AE_CommandSelector.cpp
@@ -619,6 +619,22 @@ static PF_Err UpdateParamsUI(PF_InData* in_data, PF_OutData* out_data, PF_ParamD
         auto labels = input->labelArray();
         auto values = input->valArray();
 
+        // If the input doesn't define values, match ISFEditor's behaviour and list (min,max) range
+        // TODO: for large ranges, should possibly switch to a different UI element as ISFEditor does
+        if (values.size() == 0) {
+            for (long val = input->minVal().getLongVal(); val <=      input->maxVal().getLongVal(); val++) {
+              values.push_back((int)val);
+            }
+        }
+
+        // If there are no labels, fill them in
+        // TODO: consider being defensive about possible size mismatch between values and and labels array with size > 1
+        if (labels.size() == 0) {
+          for (auto & val : values) {
+            labels.push_back(to_string(val));
+          }
+        }
+
         param.u.pd.num_choices = labels.size();
 
         auto joinedLabels = joinWith(labels, "|");

--- a/ISF4AE_UtilFunc.cpp
+++ b/ISF4AE_UtilFunc.cpp
@@ -597,7 +597,12 @@ PF_Err renderISFToCPUBuffer(PF_InData* in_data,
         case UserParamType_Long: {
           A_long index = 0;
           ERR(AEUtil::getPopupParam(in_data, out_data, paramIndex, &index));
-          auto v = input->valArray()[index - 1];  // Index of popup UI begins from 1
+          auto v = index - 1;   // Index of popup UI begins from 1
+          if (input->valArray().size() > v) {
+              v = input->valArray()[index - 1];
+          } else {
+              v = v + input->minVal().getLongVal(); // ISFEditor behaviour
+          }
           val = new VVISF::ISFVal(isfType, v);
           break;
         }


### PR DESCRIPTION
If long input does not have VALUES array, iterate MIN to MAX
If long input does not have a LABELS array, use values

This is minimal support for long inputs without VALUES and LABELS. ISFEditor goes further, switching to a different UI element if (MIN, MAX) is many values, and considering the existence of LABELS[i] on a value-by-value basis.